### PR TITLE
fix log2 and log2_e

### DIFF
--- a/src/cpu/jit_uni_eltwise.cpp
+++ b/src/cpu/jit_uni_eltwise.cpp
@@ -730,8 +730,8 @@ void jit_uni_eltwise_injector_f32<isa>::exp_prepare_table() {
 template <>
 void jit_uni_eltwise_injector_f32<avx512_common>::exp_prepare_table() {
     const unsigned int cvals[] = {
-            0x3e9a209a, // log2 = std::log(2.0f)
-            0x40549a78, // log2_e = 1.0f / log2;
+            0x3f317218, // log2 = std::log(2.0f)
+            0x3fb8aa3b, // log2_e = 1.0f / log2;
             0xc2aeac50, // expMin
             0x42b17218, // expMax
             0x3f800000,


### PR DESCRIPTION
Use `log_e(2)` and `log_2(e)` instead of `log_10(2)` and `log_2(10)`.